### PR TITLE
chore: remove projects/ from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,6 @@ frontend/dist/
 
 # Runtime Data / Sessions
 .sessions/
-projects/
 
 # Claude and Project files
 .claude/


### PR DESCRIPTION
## Summary
- Remove `projects/` from `.gitignore` to allow tracking of the projects directory

## Changes
- Removed `projects/` entry from `.gitignore`