### PR TITLE
feat: Add project card components with live session tracking

### DIFF
--- a/frontend/src/components/features/projects/ProjectCard.tsx
+++ b/frontend/src/components/features/projects/ProjectCard.tsx
@@ -1,0 +1,119 @@
+import { Project, Agent } from '@/lib/api';
+import { BaseCard, DeleteButton, Avatar } from '@/ui';
+import { CardHeader, CardContent } from '@/components/ui/primitives/card';
+
+interface ProjectCardProps {
+  project: Project;
+  agents: Agent[];
+  isSelected: boolean;
+  runningSessionsCount?: number;
+  onClick: () => void;
+  onDelete: () => void;
+}
+
+const isProjectArchived = (project: Project): boolean => {
+  return !!project.deleted_at;
+};
+
+export function ProjectCard({
+  project,
+  agents,
+  isSelected,
+  runningSessionsCount = 0,
+  onClick,
+  onDelete,
+}: ProjectCardProps) {
+  const archived = isProjectArchived(project);
+
+  // Get assigned agents (team members)
+  const assignedAgents = agents.filter(agent =>
+    project.team_member_ids?.includes(agent.id)
+  );
+
+  // Build description text
+  let descriptionText = project.description || '';
+  if (archived) {
+    descriptionText = descriptionText ? `Archived • ${descriptionText}` : 'Archived';
+  }
+
+  return (
+    <div className="group relative">
+      <BaseCard
+        onClick={onClick}
+        isSelected={isSelected}
+        className="w-full"
+      >
+        <CardHeader className="p-3 pb-2">
+          {/* Row 1: Name + Agents - with space for delete button */}
+          <div className="flex items-center justify-between gap-2 pr-8">
+            <h3 className="type-subtitle truncate flex-1 min-w-0">
+              {project.name}
+            </h3>
+
+            {/* Assigned Agents */}
+              {assignedAgents.length > 0 ? (
+                <div className="flex -space-x-2 flex-shrink-0">
+                  {assignedAgents.slice(0, 3).map((agent, index) => (
+                    <div
+                      key={agent.id}
+                      className="w-6 h-6 rounded-full border-2 border-white"
+                      style={{ zIndex: assignedAgents.length - index }}
+                      title={agent.name}
+                    >
+                      <Avatar
+                        seed={agent.id}
+                        size={24}
+                        className="w-full h-full"
+                        color={agent.icon_color}
+                      />
+                    </div>
+                  ))}
+                  {assignedAgents.length > 3 && (
+                    <div
+                      className="w-6 h-6 rounded-full border-2 border-white bg-gray-300 flex items-center justify-center text-[10px] font-bold text-gray-700"
+                      style={{ zIndex: 0 }}
+                      title={`+${assignedAgents.length - 3} more agents`}
+                    >
+                      +{assignedAgents.length - 3}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div
+                  className="w-6 h-6 rounded-full bg-gray-200 flex items-center justify-center text-gray-500 text-xs flex-shrink-0"
+                  title="No agents assigned"
+                >
+                  ?
+                </div>
+              )}
+          </div>
+        </CardHeader>
+
+        <CardContent className="p-3 pt-0">
+          {/* Row 2: Description + Running Sessions Badge - extends to edge, below delete button */}
+          <div className="flex items-center justify-between gap-2">
+              <p className="type-caption truncate flex-1 min-w-0">
+                {descriptionText || '\u00A0'}
+              </p>
+
+              {/* Running Sessions Badge - on the right */}
+              {runningSessionsCount > 0 && (
+                <div className="flex items-center gap-1 px-2 py-0.5 bg-blue-50 text-blue-700 rounded-full text-xs font-medium flex-shrink-0">
+                  <div className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-pulse" />
+                  {runningSessionsCount}
+                </div>
+              )}
+          </div>
+        </CardContent>
+      </BaseCard>
+
+      <DeleteButton
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+        title={`Delete ${project.name}`}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/features/projects/ProjectSwitcher.tsx
+++ b/frontend/src/components/features/projects/ProjectSwitcher.tsx
@@ -1,0 +1,264 @@
+import { useState, useEffect, useRef } from 'react';
+import { Search, Folder, Plus, X, Loader2 } from 'lucide-react';
+import { api, Project } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+interface ProjectSwitcherProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectProject: (projectId: string) => void;
+  onCreateProject: () => void;
+  currentProjectId?: string;
+}
+
+export function ProjectSwitcher({
+  isOpen,
+  onClose,
+  onSelectProject,
+  onCreateProject,
+  currentProjectId,
+}: ProjectSwitcherProps) {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadProjects();
+      setSearchQuery('');
+      setSelectedIndex(0);
+      setTimeout(() => searchInputRef.current?.focus(), 50);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIndex((prev) => Math.min(prev + 1, filteredProjects.length));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIndex((prev) => Math.max(prev - 1, 0));
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (selectedIndex === filteredProjects.length) {
+          onCreateProject();
+          onClose();
+        } else {
+          const project = filteredProjects[selectedIndex];
+          if (project) {
+            onSelectProject(project.id);
+            onClose();
+          }
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, selectedIndex, searchQuery]);
+
+  const loadProjects = async () => {
+    setLoading(true);
+    try {
+      const data = await api.getProjects(false);
+      setProjects(data);
+    } catch (error) {
+      console.error('Failed to load projects:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const filteredProjects = projects.filter((project) => {
+    const query = searchQuery.toLowerCase();
+    return (
+      project.name.toLowerCase().includes(query) ||
+      project.description?.toLowerCase().includes(query)
+    );
+  });
+
+  const sortedProjects = [...filteredProjects].sort((a, b) => {
+    if (a.id === currentProjectId) return -1;
+    if (b.id === currentProjectId) return 1;
+    return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+  });
+
+  const recentProjects = sortedProjects.slice(0, 5);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/50 z-50"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="fixed top-20 left-1/2 -translate-x-1/2 w-full max-w-xl bg-white rounded-lg shadow-2xl z-50">
+        {/* Search Input */}
+        <div className="p-4 border-b border-gray-200">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value);
+                setSelectedIndex(0);
+              }}
+              placeholder="Search projects..."
+              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <button
+              onClick={onClose}
+              className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Projects List */}
+        <div className="max-h-96 overflow-y-auto">
+          {loading && (
+            <div className="p-8 text-center">
+              <Loader2 className="w-8 h-8 mx-auto mb-3 text-gray-400 animate-spin" />
+              <p className="text-gray-500">Loading projects...</p>
+            </div>
+          )}
+
+          {!loading && sortedProjects.length === 0 && (
+            <div className="p-8 text-center text-gray-400">
+              {searchQuery ? 'No projects found' : 'No projects yet'}
+            </div>
+          )}
+
+          {!loading && sortedProjects.length > 0 && (
+            <>
+              {!searchQuery && (
+                <div className="p-2">
+                  <div className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                    Recent Projects
+                  </div>
+                  {recentProjects.map((project, index) => (
+                    <ProjectItem
+                      key={project.id}
+                      project={project}
+                      isSelected={index === selectedIndex}
+                      isCurrent={project.id === currentProjectId}
+                      onClick={() => {
+                        onSelectProject(project.id);
+                        onClose();
+                      }}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {searchQuery && (
+                <div className="p-2">
+                  <div className="px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                    All Projects
+                  </div>
+                  {sortedProjects.map((project, index) => (
+                    <ProjectItem
+                      key={project.id}
+                      project={project}
+                      isSelected={index === selectedIndex}
+                      isCurrent={project.id === currentProjectId}
+                      onClick={() => {
+                        onSelectProject(project.id);
+                        onClose();
+                      }}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+
+          {/* Create New Project Option */}
+          <div className="p-2 border-t border-gray-200">
+            <button
+              onClick={() => {
+                onCreateProject();
+                onClose();
+              }}
+              className={cn(
+                "w-full flex items-center gap-3 px-3 py-2 rounded-md transition-colors",
+                selectedIndex === sortedProjects.length
+                  ? "bg-primary/10 text-primary"
+                  : "hover:bg-gray-100 text-gray-700"
+              )}
+            >
+              <Plus className="w-5 h-5 text-primary" />
+              <span className="font-medium">Create New Project</span>
+            </button>
+          </div>
+        </div>
+
+        {/* Footer Hint */}
+        <div className="px-4 py-2 border-t border-gray-200 bg-gray-50 text-xs text-gray-500 flex items-center justify-between rounded-b-lg">
+          <span>↑↓ Navigate • Enter Select • Esc Close</span>
+          <span className="font-mono">Cmd/Ctrl + P</span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+interface ProjectItemProps {
+  project: Project;
+  isSelected: boolean;
+  isCurrent: boolean;
+  onClick: () => void;
+}
+
+function ProjectItem({ project, isSelected, isCurrent, onClick }: ProjectItemProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "w-full flex items-center gap-3 px-3 py-2 rounded-md transition-colors text-left",
+        isSelected
+          ? "bg-primary/10 text-primary"
+          : "hover:bg-gray-100 text-gray-700"
+      )}
+    >
+      <div
+        className="w-8 h-8 rounded-md flex items-center justify-center bg-primary text-white text-sm font-bold flex-shrink-0"
+      >
+        {project.name.substring(0, 2).toUpperCase()}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-medium truncate">{project.name}</span>
+          {isCurrent && (
+            <span className="text-xs text-primary bg-primary/10 px-1.5 py-0.5 rounded">
+              Current
+            </span>
+          )}
+        </div>
+        {project.description && (
+          <p className="text-xs text-gray-500 truncate">
+            {project.description}
+          </p>
+        )}
+      </div>
+
+      <Folder className="w-4 h-4 text-gray-400 flex-shrink-0" />
+    </button>
+  );
+}

--- a/frontend/src/components/features/projects/ProjectsList.tsx
+++ b/frontend/src/components/features/projects/ProjectsList.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Plus, Folder } from 'lucide-react';
+import { api, Project, Agent } from '@/lib/api';
+import { ListLayout } from '@/components/layout/ListLayout';
+import { ProjectCard } from './ProjectCard';
+import { cn } from '@/lib/utils';
+
+interface ProjectsListProps {
+  currentProjectId?: string;
+  onSelectProject: (projectId: string) => void;
+  onDeleteProject: (projectId: string) => void;
+  onCreateProject: () => void;
+  isMobile?: boolean;
+  reloadTrigger?: number;
+  showArchived?: boolean;
+}
+
+export function ProjectsList({
+  currentProjectId,
+  onSelectProject,
+  onDeleteProject,
+  onCreateProject,
+  isMobile = false,
+  reloadTrigger,
+  showArchived = false
+}: ProjectsListProps) {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [allSessions, setAllSessions] = useState<any[]>([]);
+
+  useEffect(() => {
+    loadData();
+  }, [showArchived]);
+
+  useEffect(() => {
+    if (reloadTrigger !== undefined) {
+      loadData();
+    }
+  }, [reloadTrigger]);
+
+  // Poll for session updates every 5 seconds to keep running count live
+  useEffect(() => {
+    const interval = setInterval(() => {
+      // Only reload sessions, not projects/agents
+      api.getSessions().then(sessionsData => {
+        setAllSessions(Array.isArray(sessionsData) ? sessionsData : []);
+      }).catch(error => {
+        console.error('Failed to poll sessions:', error);
+      });
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const loadData = async () => {
+    setLoading(true);
+    try {
+      const [projectsData, agentsData, sessionsData] = await Promise.all([
+        api.getProjects(showArchived),
+        api.getAgents(),
+        api.getSessions()
+      ]);
+      setProjects(projectsData);
+      setAgents(agentsData);
+      setAllSessions(Array.isArray(sessionsData) ? sessionsData : []);
+    } catch (error) {
+      console.error('Failed to load projects data:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+
+  const filteredProjects = useMemo(() =>
+    projects.filter(project =>
+      project.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      (project.description && project.description.toLowerCase().includes(searchQuery.toLowerCase()))
+    ),
+    [projects, searchQuery]
+  );
+
+  return (
+    <ListLayout
+      searchQuery={searchQuery}
+      onSearchChange={setSearchQuery}
+      searchPlaceholder="Search projects..."
+      loading={loading}
+      isEmpty={filteredProjects.length === 0}
+      emptyIcon={Folder}
+      emptyTitle={searchQuery ? 'No projects found' : showArchived ? 'No archived projects' : 'No projects yet'}
+      emptyDescription={searchQuery ? 'Try a different search term' : 'Create one to get started'}
+      actionButtons={[
+        { icon: Plus, onClick: onCreateProject, title: 'New Project', variant: 'primary' }
+      ]}
+      isMobile={isMobile}
+    >
+      <div className={cn("flex flex-col gap-2")}>
+        {filteredProjects.map((project) => {
+          const runningCount = allSessions.filter(
+            s => s.project_id === project.id && s.status === 'working'
+          ).length;
+
+          return (
+            <ProjectCard
+              key={project.id}
+              project={project}
+              agents={agents}
+              isSelected={currentProjectId === project.id}
+              runningSessionsCount={runningCount}
+              onClick={() => onSelectProject(project.id)}
+              onDelete={() => onDeleteProject(project.id)}
+            />
+          );
+        })}
+      </div>
+    </ListLayout>
+  );
+}

--- a/frontend/src/components/features/projects/index.ts
+++ b/frontend/src/components/features/projects/index.ts
@@ -1,0 +1,3 @@
+export * from './ProjectCard';
+export * from './ProjectsList';
+export * from './ProjectSwitcher';

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -360,7 +360,7 @@ export function Projects({ currentProjectId, onProjectSelect }: ProjectsProps) {
         )}
 
         {!loading && filteredProjects.length > 0 && (
-          <div className="flex flex-col">
+          <div className="flex flex-col gap-2">
             {filteredProjects.map((project) => {
               const runningCount = allSessions.filter(
                 s => s.project_id === project.id && s.status === 'working'
@@ -370,17 +370,11 @@ export function Projects({ currentProjectId, onProjectSelect }: ProjectsProps) {
                 <ProjectCard
                   key={project.id}
                   project={project}
-                  isSelected={currentProjectId === project.id}
                   agents={agents}
+                  isSelected={currentProjectId === project.id}
                   runningSessionsCount={runningCount}
-                  onSelect={() => {
-                    selectProject(project.id);
-                  }}
-                  onEdit={() => setEditingProject(project)}
+                  onClick={() => selectProject(project.id)}
                   onDelete={() => handleDeleteProject(project.id)}
-                  onUnarchive={() => handleUnarchiveProject(project.id)}
-                  onPermanentDelete={() => handlePermanentlyDeleteProject(project.id)}
-                  onOpen={() => handleOpenProject(project.id)}
                 />
               );
             })}

--- a/frontend/src/pages/WorkplaceKanban.tsx
+++ b/frontend/src/pages/WorkplaceKanban.tsx
@@ -456,17 +456,13 @@ export default function WorkplaceKanban({ onChatContextChange, currentProjectId,
           currentProjectId={selectedProject?.id}
           reloadTrigger={projectsReloadTrigger}
           onSelectProject={handleProjectSelection}
-          onOpenProject={handleProjectSelection}
           onCreateProject={() => setShowCreateProjectDialog(true)}
-          onEditProject={(project) => setEditingProject(project)}
           onDeleteProject={(projectId) => {
             const project = projects.find(p => p.id === projectId);
             if (project) {
               handleDeleteProject(projectId, project.name);
             }
           }}
-          onUnarchiveProject={() => {}} // Not used in WorkplaceKanban
-          onPermanentDeleteProject={() => {}} // Not used in WorkplaceKanban
         />
       }
       leftSidebarFooter={<SidebarFooter />}


### PR DESCRIPTION
## Summary
- Add ProjectCard component with two-row layout matching AgentCard design
- Add ProjectsList with live polling for running sessions (5 second interval)
- Add ProjectSwitcher for quick project navigation (Cmd/Ctrl+P)
- Update Projects and WorkplaceKanban pages to use new components

## Details

### ProjectCard Layout
**Row 1:** [Project Name] [Assigned Agents Avatars] [Delete Button]
**Row 2:** [Description] [Running Sessions Badge]

- Uses BaseCard + DeleteButton pattern from AgentsList
- Matches card sizing (p-3 pb-2 / p-3 pt-0) and gap-2 spacing with AgentCard
- Shows stacked agent avatars with overflow indicator (+N more)
- Running sessions badge only appears when count > 0
- Shows "Archived" prefix for deleted projects

### ProjectsList
- Follows ListLayout pattern from AgentsList
- Live polling of sessions every 5 seconds to keep running count updated
- Search by project name or description
- Shows/hides archived projects based on prop

### ProjectSwitcher
- Keyboard shortcut: Cmd/Ctrl+P
- Arrow key navigation, Enter to select, Escape to close
- Fuzzy search through projects
- Shows recent projects first

## Test plan
- [x] Verify ProjectCard displays correctly with proper spacing
- [x] Verify delete button doesn't overlap with agent avatars
- [x] Verify running sessions badge shows live updates
- [x] Verify running sessions badge only shows when count > 0
- [x] Verify card size matches AgentCard
- [x] Verify gap between cards matches AgentsList
- [x] Verify empty description shows single line with non-breaking space
- [ ] Test ProjectSwitcher keyboard navigation
- [ ] Test on mobile viewport