### PR TITLE
fix: restrict MCP server access to agent-assigned servers only

### DIFF
--- a/backend/app/application/session_builders/assistant_builder.py
+++ b/backend/app/application/session_builders/assistant_builder.py
@@ -132,7 +132,7 @@ class AssistantSessionBuilder(SessionBuilder):
             "system_prompt": system_prompt,
             "allowed_tools": allowed_tools,
             "mcp_servers": mcp_servers,
-            "setting_sources": ["user", "project"],  # Load skills from filesystem
+            "setting_sources": ["project"],  # Load skills from project only
             "include_partial_messages": True,  # Enable streaming
             "permission_mode": "bypassPermissions",
             "hooks": {

--- a/backend/app/application/session_builders/pm_builder.py
+++ b/backend/app/application/session_builders/pm_builder.py
@@ -109,7 +109,7 @@ class PMSessionBuilder(SessionBuilder):
             "system_prompt": system_prompt,
             "allowed_tools": allowed_tools,
             "mcp_servers": mcp_servers,
-            "setting_sources": ["user", "project"],  # Load skills from filesystem
+            "setting_sources": ["project"],  # Load skills from project only
             "include_partial_messages": True,  # Enable streaming
             "permission_mode": "bypassPermissions",
             "hooks": {

--- a/backend/app/application/session_builders/specialist_builder.py
+++ b/backend/app/application/session_builders/specialist_builder.py
@@ -104,7 +104,7 @@ class SpecialistSessionBuilder(SessionBuilder):
             "system_prompt": system_prompt,
             "allowed_tools": allowed_tools,
             "mcp_servers": mcp_servers,
-            "setting_sources": ["user", "project"],  # Load skills from filesystem
+            "setting_sources": ["project"],  # Load skills from project only
             "include_partial_messages": True,  # Enable streaming
             "permission_mode": "bypassPermissions",
             "hooks": {


### PR DESCRIPTION
## Problem
After PR #10 added `setting_sources: ["user", "project"]` for Skills support, all agents gained access to ALL MCP servers from `~/.claude.json`, bypassing the agent's `allowed_mcps` filtering.

## Root Cause
The `"user"` setting source instructs the Claude SDK to load the entire `mcpServers` section from `~/.claude.json`, making all user-configured MCP servers available regardless of the agent's `allowed_mcps` configuration.

## Solution
Changed `setting_sources: ["user", "project"]` to `setting_sources: ["project"]` in all session builders.

This restricts the SDK to only load project-level settings, preventing unauthorized MCP access while maintaining skill discovery from the project's `.claude/skills/` directory.

## Changes
- `specialist_builder.py` (line 107): `["user", "project"]` → `["project"]`
- `pm_builder.py` (line 112): `["user", "project"]` → `["project"]`
- `assistant_builder.py` (line 135): `["user", "project"]` → `["project"]`

## Impact
✅ **Fixed**: Agents now only access their assigned MCP servers  
✅ **Maintained**: Skills discovery from project `.claude/skills/` directory  
⚠️ **Trade-off**: Skills from user `~/.claude/skills/` won't auto-discover (acceptable since agents are project-specific)

## Testing
- All 55 session builder unit tests passing
- Verified agents with `allowed_mcps: []` won't see unauthorized MCPs
- Verified agents with specific MCPs only see assigned + common_tools

## Verification Steps
1. Create agent with `allowed_mcps: []`
2. Create session and check available tools
3. Confirm only `common_tools` MCP is present, not all user MCPs

Related to #10