### PR TITLE
fix: add Mermaid rendering support to markdown files in FileViewerModal

### DIFF
--- a/frontend/src/components/features/files/FileViewerModal.tsx
+++ b/frontend/src/components/features/files/FileViewerModal.tsx
@@ -53,6 +53,13 @@ const markdownComponents: Components = {
         </code>
       );
     }
+
+    // Check for Mermaid diagrams
+    if (className?.includes('language-mermaid')) {
+      const code = String(children).replace(/\n$/, '');
+      return <MermaidDiagram chart={code} className="my-3" />;
+    }
+
     return (
       <code className="block bg-muted text-foreground px-3 py-2 my-3 text-sm font-mono overflow-x-auto leading-normal border border-border rounded">
         {children}


### PR DESCRIPTION
## Summary
Mermaid code blocks were not being rendered when viewing markdown files in FileViewerModal. The local `markdownComponents` definition in FileViewerModal.tsx was missing the Mermaid detection logic that exists in the shared markdownComponents.

## Changes
- Added Mermaid diagram detection in the `code` component at `FileViewerModal.tsx:46-66`
- Renders `MermaidDiagram` component when `language-mermaid` is detected
- Matches the behavior of the shared markdownComponents used in MessageBubble

## Test Plan
- [ ] Open a markdown file containing Mermaid code blocks in file viewer
- [ ] Verify Mermaid diagrams render correctly
- [ ] Verify inline code and regular code blocks still work
- [ ] Verify interactive features (fullscreen, zoom, PNG export) work from file viewer

## Related
Complements PR #14 and PR #15 for comprehensive Mermaid support.